### PR TITLE
Added Pie Chart display values threshold

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -24,6 +24,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     private float mValueLinePart1Length = 0.3f;
     private float mValueLinePart2Length = 0.4f;
     private boolean mValueLineVariableLength = true;
+    private float mDrawValuePercentThreshold = 2.0f;
 
     public PieDataSet(List<PieEntry> yVals, String label) {
         super(yVals, label);
@@ -204,6 +205,16 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     public void setValueLineVariableLength(boolean valueLineVariableLength)
     {
         this.mValueLineVariableLength = valueLineVariableLength;
+    }
+
+    /** Draw values on chart if the percent value is equal to or exceeds this percent threshold */
+    @Override public float getDrawValuePercentThreshold() {
+        return mDrawValuePercentThreshold;
+    }
+
+    public void setDrawValuePercentThreshold(float drawValuePercentThreshold)
+    {
+        this.mDrawValuePercentThreshold = drawValuePercentThreshold;
     }
 
     public enum ValuePosition {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -24,7 +24,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     private float mValueLinePart1Length = 0.3f;
     private float mValueLinePart2Length = 0.4f;
     private boolean mValueLineVariableLength = true;
-    private float mDrawValuePercentThreshold = 2.0f;
+    private float mDrawValuePercentThreshold = 0.0f;
 
     public PieDataSet(List<PieEntry> yVals, String label) {
         super(yVals, label);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
@@ -66,5 +66,9 @@ public interface IPieDataSet extends IDataSet<PieEntry> {
      * */
     boolean isValueLineVariableLength();
 
+    /**
+     *  Draw values on chart if the percent value is equal to or exceeds this threshold
+     *  */
+    float getDrawValuePercentThreshold();
 }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -471,6 +471,12 @@ public class PieChartRenderer extends DataRenderer {
                 float value = mChart.isUsePercentValuesEnabled() ? entry.getY()
                         / yValueSum * 100f : entry.getY();
 
+                // Do not draw text if percent value is less than the threshold
+                if (entry.getY() / yValueSum * 100f < dataSet.getDrawValuePercentThreshold()) {
+                    xIndex++;
+                    continue;
+                }
+
                 final float sliceXBase = (float) Math.cos(transformedAngle * Utils.FDEG2RAD);
                 final float sliceYBase = (float) Math.sin(transformedAngle * Utils.FDEG2RAD);
 


### PR DESCRIPTION
Added a new PieDataSet option to not draw pie chart slice text if percent value is less than a configurable threshold (threshold defaults to 0.0% so text is normally always drawn).

Merging into andromeda-0.2 branch since it is based on the v3.0.2 release contour.