### PR TITLE
Labels at specific positions for x and y axis #2692

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
@@ -148,6 +148,16 @@ public abstract class AxisBase extends ComponentBase {
     public float mAxisRange = 0f;
 
     /**
+     * if true, then labels are displayed using specificLabelPositions instead of computed ones
+     */
+    private boolean showSpecificLabelPositions = false;
+
+    /**
+     * specify to which values labels must be displayed. has no effect if not used showSpecificLabelPositions set to true
+     */
+    private float[] specificLabelPositions = new float[]{};
+
+    /**
      * default constructor
      */
     public AxisBase() {
@@ -762,5 +772,28 @@ public abstract class AxisBase extends ComponentBase {
     public void setSpaceMax(float mSpaceMax)
     {
         this.mSpaceMax = mSpaceMax;
+    }
+
+    /**
+     * if set to true, labels will be displayed at the specific positions passed in via setSpecificLabelPositions
+     */
+    public void setShowSpecificLabelPositions(boolean showSpecificLabelPositions)
+    {
+        this.showSpecificLabelPositions = showSpecificLabelPositions;
+    }
+
+    public boolean isShowSpecificLabelPositions()
+    {
+        return showSpecificLabelPositions;
+    }
+
+    public void setSpecificLabelPositions(float[] specificLabelPositions)
+    {
+        this.specificLabelPositions = specificLabelPositions;
+    }
+
+    public float[] getSpecificLabelPositions()
+    {
+        return specificLabelPositions;
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -184,13 +184,20 @@ public class XAxisRenderer extends AxisRenderer {
 
         float[] positions = new float[mXAxis.mEntryCount * 2];
 
-        for (int i = 0; i < positions.length; i += 2) {
+        if (mXAxis.isShowSpecificLabelPositions()) {
+            positions = new float[mXAxis.getSpecificLabelPositions().length * 2];
+            for (int i = 0; i < positions.length; i += 2) {
+                positions[i] = mXAxis.getSpecificLabelPositions()[i / 2];
+            }
+        } else {
+            for (int i = 0; i < positions.length; i += 2) {
 
-            // only fill x values
-            if (centeringEnabled) {
-                positions[i] = mXAxis.mCenteredEntries[i / 2];
-            } else {
-                positions[i] = mXAxis.mEntries[i / 2];
+                // only fill x values
+                if (centeringEnabled) {
+                    positions[i] = mXAxis.mCenteredEntries[i / 2];
+                } else {
+                    positions[i] = mXAxis.mEntries[i / 2];
+                }
             }
         }
 
@@ -202,7 +209,9 @@ public class XAxisRenderer extends AxisRenderer {
 
             if (mViewPortHandler.isInBoundsX(x)) {
 
-                String label = mXAxis.getValueFormatter().getFormattedValue(mXAxis.mEntries[i / 2], mXAxis);
+                String label = mXAxis.isShowSpecificLabelPositions() ?
+                        mXAxis.getValueFormatter().getFormattedValue(mXAxis.getSpecificLabelPositions()[i / 2], mXAxis)
+                        : mXAxis.getValueFormatter().getFormattedValue(mXAxis.mEntries[i / 2], mXAxis);
 
                 if (mXAxis.isAvoidFirstLastClippingEnabled()) {
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -114,6 +114,23 @@ public class YAxisRenderer extends AxisRenderer {
      */
     protected void drawYLabels(Canvas c, float fixedPosition, float[] positions, float offset) {
 
+        if (mYAxis.isShowSpecificLabelPositions()) {
+            float[] specificLabelsPositions = new float[mYAxis.getSpecificLabelPositions().length * 2];
+            for (int i = 0; i < mYAxis.getSpecificLabelPositions().length; i++) {
+                specificLabelsPositions[i * 2 + 1] = mYAxis.getSpecificLabelPositions()[i];
+            }
+            mTrans.pointValuesToPixel(specificLabelsPositions);
+
+            for (int i = 0; i < mYAxis.getSpecificLabelPositions().length; i++) {
+                float y = specificLabelsPositions[i * 2 + 1];
+                if (mViewPortHandler.isInBoundsY(y)) {
+                    String text = mYAxis.getValueFormatter().getFormattedValue(mYAxis.getSpecificLabelPositions()[i], mYAxis);
+                    c.drawText(text, fixedPosition, y + offset, mAxisLabelPaint);
+                }
+            }
+            return;
+        }
+
         final int from = mYAxis.isDrawBottomYLabelEntryEnabled() ? 0 : 1;
         final int to = mYAxis.isDrawTopYLabelEntryEnabled()
                 ? mYAxis.mEntryCount


### PR DESCRIPTION
This PR is for showing labels at specific positions on the X and Y axis. 
There's a special requirement to show labels at specific points on WiFi Channel Map chart. Without this change, displayed labels on the (x-axis) were random and not meaningful. 

Note: These changes were taken from one of the pull request of MPAndroid chart.