### PR TITLE
Fix for ArrayIndexOutOfBoundsException - when highlighting full bar on CombinedChart

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CombinedChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CombinedChart.java
@@ -116,6 +116,7 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Com
             // For isHighlightFullBarEnabled, remove stackIndex
             return new Highlight(h.getX(), h.getY(),
                     h.getXPx(), h.getYPx(),
+                    h.getDataIndex(),
                     h.getDataSetIndex(), -1, h.getAxis());
         }
     }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/Highlight.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/Highlight.java
@@ -102,6 +102,22 @@ public class Highlight {
     }
 
     /**
+     * Constructor, only used for for Combined Chart.
+     *
+     * @param x            the index of the highlighted value on the x-axis
+     * @param y            the y-value of the highlighted value
+     * @param dataIndex    the index of the highlighted data entry
+     * @param dataSetIndex the index of the DataSet the highlighted value belongs to
+     * @param stackIndex   references which value of a stacked-bar entry has been
+     *                     selected
+     */
+    public Highlight(float x, float y, float xPx, float yPx, int dataIndex, int dataSetIndex, int stackIndex, YAxis.AxisDependency axis) {
+        this(x, y, xPx, yPx, dataSetIndex, axis);
+        this.mStackIndex = stackIndex;
+        this.mDataIndex = dataIndex;
+    }
+
+    /**
      * returns the x-value of the highlighted value
      *
      * @return


### PR DESCRIPTION
When using Combined Chart, if HighlightFullBarEnabled is true, selecting  or highlighting any data on the chart results in crash with ArrayIndexOutOfBoundException.

