### PR TITLE
Update our custom MPAndroid chart to be based on the official v3.1.0 release

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CombinedChart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/CombinedChart.java
@@ -119,6 +119,7 @@ public class CombinedChart extends BarLineChartBase<CombinedData> implements Com
             // For isHighlightFullBarEnabled, remove stackIndex
             return new Highlight(h.getX(), h.getY(),
                     h.getXPx(), h.getYPx(),
+                    h.getDataIndex(),
                     h.getDataSetIndex(), -1, h.getAxis());
         }
     }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
@@ -152,6 +152,16 @@ public abstract class AxisBase extends ComponentBase {
     public float mAxisRange = 0f;
 
     /**
+     * if true, then labels are displayed using specificLabelPositions instead of computed ones
+     */
+    private boolean showSpecificLabelPositions = false;
+
+    /**
+     * specify to which values labels must be displayed. has no effect if not used showSpecificLabelPositions set to true
+     */
+    private float[] specificLabelPositions = new float[]{};
+
+    /**
      * default constructor
      */
     public AxisBase() {
@@ -778,5 +788,28 @@ public abstract class AxisBase extends ComponentBase {
     public void setSpaceMax(float mSpaceMax)
     {
         this.mSpaceMax = mSpaceMax;
+    }
+
+    /**
+     * if set to true, labels will be displayed at the specific positions passed in via setSpecificLabelPositions
+     */
+    public void setShowSpecificLabelPositions(boolean showSpecificLabelPositions)
+    {
+        this.showSpecificLabelPositions = showSpecificLabelPositions;
+    }
+
+    public boolean isShowSpecificLabelPositions()
+    {
+        return showSpecificLabelPositions;
+    }
+
+    public void setSpecificLabelPositions(float[] specificLabelPositions)
+    {
+        this.specificLabelPositions = specificLabelPositions;
+    }
+
+    public float[] getSpecificLabelPositions()
+    {
+        return specificLabelPositions;
     }
 }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/DataSet.java
@@ -291,6 +291,8 @@ public abstract class DataSet<T extends Entry> extends BaseDataSet<T> {
 
     @Override
     public T getEntryForIndex(int index) {
+        // Avoid an IndexOutOfBoundsException if we try access an item outside out list
+        if (index >= mValues.size()) return null;
         return mValues.get(index);
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -29,6 +29,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     private float mValueLinePart1Length = 0.3f;
     private float mValueLinePart2Length = 0.4f;
     private boolean mValueLineVariableLength = true;
+    private float mDrawValuePercentThreshold = 2.0f;
 
     public PieDataSet(List<PieEntry> yVals, String label) {
         super(yVals, label);
@@ -216,6 +217,16 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
 
     public void setValueLineVariableLength(boolean valueLineVariableLength) {
         this.mValueLineVariableLength = valueLineVariableLength;
+    }
+
+    /** Draw values on chart if the percent value is equal to or exceeds this percent threshold */
+    @Override public float getDrawValuePercentThreshold() {
+        return mDrawValuePercentThreshold;
+    }
+
+    public void setDrawValuePercentThreshold(float drawValuePercentThreshold)
+    {
+        this.mDrawValuePercentThreshold = drawValuePercentThreshold;
     }
 
     public enum ValuePosition {

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/data/PieDataSet.java
@@ -29,7 +29,7 @@ public class PieDataSet extends DataSet<PieEntry> implements IPieDataSet {
     private float mValueLinePart1Length = 0.3f;
     private float mValueLinePart2Length = 0.4f;
     private boolean mValueLineVariableLength = true;
-    private float mDrawValuePercentThreshold = 2.0f;
+    private float mDrawValuePercentThreshold = 0.0f;
 
     public PieDataSet(List<PieEntry> yVals, String label) {
         super(yVals, label);

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/Highlight.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/highlight/Highlight.java
@@ -102,6 +102,22 @@ public class Highlight {
     }
 
     /**
+     * Constructor, only used for for Combined Chart.
+     *
+     * @param x            the index of the highlighted value on the x-axis
+     * @param y            the y-value of the highlighted value
+     * @param dataIndex    the index of the highlighted data entry
+     * @param dataSetIndex the index of the DataSet the highlighted value belongs to
+     * @param stackIndex   references which value of a stacked-bar entry has been
+     *                     selected
+     */
+    public Highlight(float x, float y, float xPx, float yPx, int dataIndex, int dataSetIndex, int stackIndex, YAxis.AxisDependency axis) {
+        this(x, y, xPx, yPx, dataSetIndex, axis);
+        this.mStackIndex = stackIndex;
+        this.mDataIndex = dataIndex;
+    }
+
+    /**
      * returns the x-value of the highlighted value
      *
      * @return

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/interfaces/datasets/IPieDataSet.java
@@ -70,5 +70,9 @@ public interface IPieDataSet extends IDataSet<PieEntry> {
      * */
     boolean isValueLineVariableLength();
 
+    /**
+     *  Draw values on chart if the percent value is equal to or exceeds this threshold
+     *  */
+    float getDrawValuePercentThreshold();
 }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -571,7 +571,7 @@ public class LineChartRenderer extends LineRadarRenderer {
                         drawValue(c, formatter.getPointLabel(entry), x, y - valOffset, dataSet.getValueTextColor(j / 2));
                     }
 
-                    if (entry.getIcon() != null && dataSet.isDrawIconsEnabled()) {
+                    if (entry != null && entry.getIcon() != null && dataSet.isDrawIconsEnabled()) {
 
                         Drawable icon = entry.getIcon();
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -58,7 +58,7 @@ public class LineChartRenderer extends LineRadarRenderer {
     protected Path cubicFillPath = new Path();
 
     // Andromeda Additions
-    private float noDataValue = -Float.MAX_VALUE;
+    private float noDataValue = Float.NaN;
     private float noDataTransitionWidth = 0.33f; // As a percent of the normal entry width
     public void setNoDataValue(float noDataValue) {
         this.noDataValue = noDataValue;
@@ -70,7 +70,7 @@ public class LineChartRenderer extends LineRadarRenderer {
         return (isNoDataValue(entry) ? fillMin : entry.getY());
     }
     private boolean isNoDataValue(Entry entry) {
-        return (entry == null || entry.getY() <= noDataValue);
+        return (entry == null || entry.getY() == noDataValue);
     }
 
     public LineChartRenderer(LineDataProvider chart, ChartAnimator animator,

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -57,6 +57,22 @@ public class LineChartRenderer extends LineRadarRenderer {
     protected Path cubicPath = new Path();
     protected Path cubicFillPath = new Path();
 
+    // Andromeda Additions
+    private float noDataValue = Float.MIN_VALUE;
+    private float noDataTransitionWidth = 0.33f; // As a percent of the normal entry width
+    public void setNoDataValue(float noDataValue) {
+        this.noDataValue = noDataValue;
+    }
+    public void setNoDataTransitionWidth(float noDataTransitionWidth) {
+        this.noDataTransitionWidth = noDataTransitionWidth;
+    }
+    private float getAdjustedY(Entry entry, float fillMin) {
+        return (isNoDataValue(entry) ? fillMin : entry.getY());
+    }
+    private boolean isNoDataValue(Entry entry) {
+        return (entry == null || entry.getY() <= noDataValue);
+    }
+
     public LineChartRenderer(LineDataProvider chart, ChartAnimator animator,
                              ViewPortHandler viewPortHandler) {
         super(animator, viewPortHandler);
@@ -394,24 +410,48 @@ public class LineChartRenderer extends LineRadarRenderer {
 
                     if (e1 == null || e2 == null) continue;
 
+                    if (isNoDataValue(e1) || (!isDrawSteppedEnabled && isNoDataValue(e2))) {
+                        // If the previous sample is valid but the current one is not
+                        if(!isNoDataValue(e1) && isNoDataValue(e2)) {
+                            // Draw a no data transition leaving the previous entry
+                            mLineBuffer[j++] = e1.getX();
+                            mLineBuffer[j++] = e1.getY() * phaseY;
+                            mLineBuffer[j++] = e1.getX() + noDataTransitionWidth;
+                            mLineBuffer[j++] = e1.getY() * phaseY;
+                        }
+                        // If the previous sample was not valid and the current one is valid
+                        else if(isNoDataValue(e1) && !isNoDataValue(e2) && !isDrawSteppedEnabled) {
+                            // Draw a no data transition entering the current entry
+                            mLineBuffer[j++] = e2.getX() - noDataTransitionWidth;
+                            mLineBuffer[j++] = e2.getY() * phaseY;
+                            mLineBuffer[j++] = e2.getX();
+                            mLineBuffer[j++] = e2.getY() * phaseY;
+                        }
+                        continue;
+                    }
+
                     mLineBuffer[j++] = e1.getX();
                     mLineBuffer[j++] = e1.getY() * phaseY;
 
                     if (isDrawSteppedEnabled) {
                         mLineBuffer[j++] = e2.getX();
                         mLineBuffer[j++] = e1.getY() * phaseY;
-                        mLineBuffer[j++] = e2.getX();
-                        mLineBuffer[j++] = e1.getY() * phaseY;
+                        if (!isNoDataValue(e2)) {
+                            mLineBuffer[j++] = e2.getX();
+                            mLineBuffer[j++] = e1.getY() * phaseY;
+                        }
                     }
 
-                    mLineBuffer[j++] = e2.getX();
-                    mLineBuffer[j++] = e2.getY() * phaseY;
+                    if (!isNoDataValue(e2)) {
+                        mLineBuffer[j++] = e2.getX();
+                        mLineBuffer[j++] = e2.getY() * phaseY;
+                    }
                 }
 
                 if (j > 0) {
                     trans.pointValuesToPixel(mLineBuffer);
 
-                    final int size = Math.max((mXBounds.range + 1) * pointsPerEntryPair, pointsPerEntryPair) * 2;
+                    final int size = j; // Math.max((mXBounds.range + 1) * pointsPerEntryPair, pointsPerEntryPair) * 2;
 
                     mRenderPaint.setColor(dataSet.getColor());
 
@@ -493,7 +533,7 @@ public class LineChartRenderer extends LineRadarRenderer {
         final Entry entry = dataSet.getEntryForIndex(startIndex);
 
         filled.moveTo(entry.getX(), fillMin);
-        filled.lineTo(entry.getX(), entry.getY() * phaseY);
+        filled.lineTo(entry.getX(), getAdjustedY(entry, fillMin) * phaseY);
 
         // create a new path
         Entry currentEntry = null;
@@ -502,11 +542,27 @@ public class LineChartRenderer extends LineRadarRenderer {
 
             currentEntry = dataSet.getEntryForIndex(x);
 
+            // Changes to show gaps for no data.  Note: The stepped and non-stepped implementations
+            // are similar and could be optimized for code size however That will make each code path
+            // harder to follow.
             if (isDrawSteppedEnabled) {
-                filled.lineTo(currentEntry.getX(), previousEntry.getY() * phaseY);
+                filled.lineTo(currentEntry.getX(), getAdjustedY(previousEntry, fillMin) * phaseY);
+                filled.lineTo(currentEntry.getX(), getAdjustedY(currentEntry, fillMin) * phaseY);
+            } else {
+                if (isNoDataValue(previousEntry)) {
+                    if (!isNoDataValue(currentEntry)) {
+                        filled.lineTo(currentEntry.getX() - noDataTransitionWidth, getAdjustedY(previousEntry, fillMin) * phaseY);
+                        filled.lineTo(currentEntry.getX() - noDataTransitionWidth, getAdjustedY(currentEntry, fillMin) * phaseY);
+                    }
+                    else {
+                        filled.lineTo(currentEntry.getX(), getAdjustedY(previousEntry, fillMin) * phaseY);
+                    }
+                } else if (isNoDataValue(currentEntry)) {
+                    filled.lineTo(previousEntry.getX() + noDataTransitionWidth, getAdjustedY(previousEntry, fillMin) * phaseY);
+                    filled.lineTo(previousEntry.getX() + noDataTransitionWidth, fillMin * phaseY);
+                }
+                filled.lineTo(currentEntry.getX(), getAdjustedY(currentEntry, fillMin) * phaseY);
             }
-
-            filled.lineTo(currentEntry.getX(), currentEntry.getY() * phaseY);
 
             previousEntry = currentEntry;
         }

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -58,7 +58,7 @@ public class LineChartRenderer extends LineRadarRenderer {
     protected Path cubicFillPath = new Path();
 
     // Andromeda Additions
-    private float noDataValue = Float.MIN_VALUE;
+    private float noDataValue = -Float.MAX_VALUE;
     private float noDataTransitionWidth = 0.33f; // As a percent of the normal entry width
     public void setNoDataValue(float noDataValue) {
         this.noDataValue = noDataValue;

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/PieChartRenderer.java
@@ -501,6 +501,12 @@ public class PieChartRenderer extends DataRenderer {
                 String formattedValue = formatter.getPieLabel(value, entry);
                 String entryLabel = entry.getLabel();
 
+                // Do not draw text if percent value is less than the threshold
+                if (entry.getY() / yValueSum * 100f < dataSet.getDrawValuePercentThreshold()) {
+                    xIndex++;
+                    continue;
+                }
+
                 final float sliceXBase = (float) Math.cos(transformedAngle * Utils.FDEG2RAD);
                 final float sliceYBase = (float) Math.sin(transformedAngle * Utils.FDEG2RAD);
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -183,13 +183,20 @@ public class XAxisRenderer extends AxisRenderer {
 
         float[] positions = new float[mXAxis.mEntryCount * 2];
 
-        for (int i = 0; i < positions.length; i += 2) {
+        if (mXAxis.isShowSpecificLabelPositions()) {
+            positions = new float[mXAxis.getSpecificLabelPositions().length * 2];
+            for (int i = 0; i < positions.length; i += 2) {
+                positions[i] = mXAxis.getSpecificLabelPositions()[i / 2];
+            }
+        } else {
+            for (int i = 0; i < positions.length; i += 2) {
 
-            // only fill x values
-            if (centeringEnabled) {
-                positions[i] = mXAxis.mCenteredEntries[i / 2];
-            } else {
-                positions[i] = mXAxis.mEntries[i / 2];
+                // only fill x values
+                if (centeringEnabled) {
+                    positions[i] = mXAxis.mCenteredEntries[i / 2];
+                } else {
+                    positions[i] = mXAxis.mEntries[i / 2];
+                }
             }
         }
 
@@ -201,7 +208,9 @@ public class XAxisRenderer extends AxisRenderer {
 
             if (mViewPortHandler.isInBoundsX(x)) {
 
-                String label = mXAxis.getValueFormatter().getAxisLabel(mXAxis.mEntries[i / 2], mXAxis);
+                String label = mXAxis.isShowSpecificLabelPositions() ?
+                        mXAxis.getValueFormatter().getAxisLabel(mXAxis.getSpecificLabelPositions()[i / 2], mXAxis)
+                        : mXAxis.getValueFormatter().getAxisLabel(mXAxis.mEntries[i / 2], mXAxis);
 
                 if (mXAxis.isAvoidFirstLastClippingEnabled()) {
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/YAxisRenderer.java
@@ -114,6 +114,23 @@ public class YAxisRenderer extends AxisRenderer {
      */
     protected void drawYLabels(Canvas c, float fixedPosition, float[] positions, float offset) {
 
+        if (mYAxis.isShowSpecificLabelPositions()) {
+            float[] specificLabelsPositions = new float[mYAxis.getSpecificLabelPositions().length * 2];
+            for (int i = 0; i < mYAxis.getSpecificLabelPositions().length; i++) {
+                specificLabelsPositions[i * 2 + 1] = mYAxis.getSpecificLabelPositions()[i];
+            }
+            mTrans.pointValuesToPixel(specificLabelsPositions);
+
+            for (int i = 0; i < mYAxis.getSpecificLabelPositions().length; i++) {
+                float y = specificLabelsPositions[i * 2 + 1];
+                if (mViewPortHandler.isInBoundsY(y)) {
+                    String text = mYAxis.getValueFormatter().getFormattedValue(mYAxis.getSpecificLabelPositions()[i], mYAxis);
+                    c.drawText(text, fixedPosition, y + offset, mAxisLabelPaint);
+                }
+            }
+            return;
+        }
+
         final int from = mYAxis.isDrawBottomYLabelEntryEnabled() ? 0 : 1;
         final int to = mYAxis.isDrawTopYLabelEntryEnabled()
                 ? mYAxis.mEntryCount


### PR DESCRIPTION
See https://handheldnetworktools.atlassian.net/browse/AW-14504

It was previously based on the v3.1.0-alpha release.  But this contour could no longer be built (see chore listed above for details). 

First, I synced the master branch of the NetAlly fork with the official MPAndroidChart master branch.  I then started the netally-main branch at the official v.3.1.0 contour.

And then for this PR, I cherry picked all of our NetAlly customization and modification commits (8 total) into this PR branch off of netally-main.

